### PR TITLE
Mostly working receive implementation

### DIFF
--- a/drivers/wireless/lpwan/rn2483/rn2483.c
+++ b/drivers/wireless/lpwan/rn2483/rn2483.c
@@ -58,10 +58,12 @@
 #define CONFIG_LPWAN_RN2483_FREQ 433050000
 #endif /* CONFIG_LPWAN_RN2483_FREQ */
 
-#if (CONFIG_LPWAN_RN2483_FREQ < 433000000 ||                                           \
-     (CONFIG_LPWAN_RN2483_FREQ > 434800000 && CONFIG_LPWAN_RN2483_FREQ < 863000000) || \
+#if (CONFIG_LPWAN_RN2483_FREQ < 433000000 ||                                 \
+     (CONFIG_LPWAN_RN2483_FREQ > 434800000 &&                                \
+      CONFIG_LPWAN_RN2483_FREQ < 863000000) ||                               \
      CONFIG_LPWAN_RN2483_FREQ > 870000000)
-#error "RN2483 frequency has to be between 433000000 and 434800000, or between 863000000 and 870000000, in Hz"
+#error                                                                       \
+    "RN2483 frequency has to be between 433000000 and 434800000, or between 863000000 and 870000000, in Hz"
 #endif /* Bandwidth value check */
 
 /* Sync word */
@@ -82,7 +84,7 @@
 #define CONFIG_LPWAN_RN2483_BW 500
 #endif /* CONFIG_LPWAN_RN2483_BW */
 
-#if (CONFIG_LPWAN_RN2483_BW != 125 && CONFIG_LPWAN_RN2483_BW != 250 && \
+#if (CONFIG_LPWAN_RN2483_BW != 125 && CONFIG_LPWAN_RN2483_BW != 250 &&       \
      CONFIG_LPWAN_RN2483_BW != 500)
 #error "RN2483 bandwidth can only be one of 125, 250 and 500kHz"
 #endif /* Bandwidth value check */
@@ -160,6 +162,8 @@ struct rn2483_config_s
 struct rn2483_dev_s
 {
   FAR struct file uart; /* Underlying UART interface */
+  bool receiving; /* Mark radio as receiving between read calls in case buffer
+                     was too small */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   bool unlinked;                 /* True means driver is unlinked */
 #endif                           /* CONFIG_DISABLE_PSEUDOFS_OPERATIONS */
@@ -191,16 +195,24 @@ static ssize_t rn2483_read(FAR struct file *filep, FAR char *buffer,
                            size_t buflen);
 static int rn2483_ioctl(FAR struct file *filep, int cmd, unsigned long arg);
 static int rn2483_unlink(FAR struct inode *inode);
-static int rn2483_radio_set_cr(FAR struct rn2483_dev_s *priv, enum rn2483_cr_e cr);
-static int rn2483_radio_set_mod(FAR struct rn2483_dev_s *priv, enum rn2483_mod_e mod);
-static int rn2483_radio_set_freq(FAR struct rn2483_dev_s *priv, uint32_t freq);
+
+static int rn2483_radio_set_cr(FAR struct rn2483_dev_s *priv,
+                               enum rn2483_cr_e cr);
+static int rn2483_radio_set_mod(FAR struct rn2483_dev_s *priv,
+                                enum rn2483_mod_e mod);
+static int rn2483_radio_set_freq(FAR struct rn2483_dev_s *priv,
+                                 uint32_t freq);
 static int rn2483_radio_set_bw(FAR struct rn2483_dev_s *priv, uint16_t bw);
-static int rn2483_radio_set_prlen(FAR struct rn2483_dev_s *priv, uint16_t prlen);
+static int rn2483_radio_set_prlen(FAR struct rn2483_dev_s *priv,
+                                  uint16_t prlen);
 static int rn2483_radio_set_crc(FAR struct rn2483_dev_s *priv, bool crc);
 static int rn2483_radio_set_iqi(FAR struct rn2483_dev_s *priv, bool iqi);
 static int rn2483_radio_set_pwr(FAR struct rn2483_dev_s *priv, int8_t pwr);
 static int rn2483_radio_set_sf(FAR struct rn2483_dev_s *priv, uint8_t sf);
 static int rn2483_radio_set_sync(FAR struct rn2483_dev_s *priv, uint8_t sync);
+static int rn2483_read_response(FAR struct rn2483_dev_s *priv, char *buf,
+                                size_t buf_len);
+static int rn2483_set_config(FAR struct rn2483_dev_s *priv);
 
 /****************************************************************************
  * Private Data
@@ -266,9 +278,9 @@ static int rn2483_open(FAR struct file *filep)
 
   err = nxmutex_lock(&priv->devlock);
   if (err < 0)
-  {
-    return err;
-  }
+    {
+      return err;
+    }
 
   /* Increment the count of open references on the driver */
 
@@ -297,9 +309,9 @@ static int rn2483_close(FAR struct file *filep)
 
   err = nxmutex_lock(&priv->devlock);
   if (err < 0)
-  {
-    return err;
-  }
+    {
+      return err;
+    }
 
   /* Decrement the count of open references on the driver */
 
@@ -311,12 +323,12 @@ static int rn2483_close(FAR struct file *filep)
    */
 
   if (priv->crefs <= 0 && priv->unlinked)
-  {
-    file_close(&priv->uart);
-    nxmutex_destroy(&priv->devlock);
-    kmm_free(priv);
-    return 0;
-  }
+    {
+      file_close(&priv->uart);
+      nxmutex_destroy(&priv->devlock);
+      kmm_free(priv);
+      return 0;
+    }
 
   nxmutex_unlock(&priv->devlock);
   return 0;
@@ -334,56 +346,210 @@ static int rn2483_close(FAR struct file *filep)
 static ssize_t rn2483_read(FAR struct file *filep, FAR char *buffer,
                            size_t buflen)
 {
-  syslog(LOG_INFO, "Enter read\n");
-
   FAR struct inode *inode = filep->f_inode;
   FAR struct rn2483_dev_s *priv = inode->i_private;
   ssize_t length = 0;
+  ssize_t received;
   int err;
+  char response[30] = {0}; // TODO: shortest length?
 
-  /* If file position is non-zero, then we're at the end of file. */
+  /* If file position is non-zero but we're marked as no longer receiving,
+   * then the whole transmission has been consumed. Set a filepos of 0 to
+   * signal EOF.
+   */
 
-  if (filep->f_pos > 0)
-  {
-    return 0;
-  }
+  if (priv->receiving == false && filep->f_pos > 0)
+    {
+      filep->f_pos = 0;
+      return 0;
+    }
+
+  /* We're setting a new receive call, mark as receiving */
+
+  priv->receiving = true;
 
   /* Get exclusive access */
 
   err = nxmutex_lock(&priv->devlock);
   if (err < 0)
-  {
-    return err;
-  }
+    {
+      priv->receiving = false;
+      return err;
+    }
 
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   if (priv->unlinked)
-  {
-    /* Do not allow operations on unlinked drivers. */
+    {
+      /* Do not allow operations on unlinked drivers. */
 
-    nxmutex_unlock(&priv->devlock);
-    return 0;
-  }
+      priv->receiving = false;
+      nxmutex_unlock(&priv->devlock);
+      return 0;
+    }
 #endif
 
-  // TODO actually receive
+  /* Must send 'mac pause' command before every receive command */
 
-  // For now just get the radio version info
-  char command[] = "sys get ver\r\n";
-  length = file_write(&priv->uart, command, sizeof(command));
+  char pause[] = "mac pause\r\n";
+  length = file_write(&priv->uart, pause, sizeof(pause));
   if (length < 0)
-  {
-    // TODO: log error
-    nxmutex_unlock(&priv->devlock);
-    return length;
-  }
+    {
+      priv->receiving = false;
+      nxmutex_unlock(&priv->devlock);
+      return length;
+    }
 
-  // Read back the version string
-  length = file_read(&priv->uart, buffer, buflen);
+  /* Check how the radio responded to MAC pause */
 
-  filep->f_pos += length;
+  length = rn2483_read_response(priv, response, sizeof(response) - 1);
+  if (length < 0)
+    {
+      priv->receiving = false;
+      nxmutex_unlock(&priv->devlock);
+      return length;
+    }
+
+  /* We should be pausing for the max duration */
+
+  if (!strstr(response, "4294967245"))
+    {
+      priv->receiving = false;
+      nxmutex_unlock(&priv->devlock);
+      return -EIO;
+    }
+
+  /* Get into continuous receive */
+
+  char rx[] = "radio rx 0\r\n";
+  length = file_write(&priv->uart, rx, sizeof(rx));
+  if (length < 0)
+    {
+      priv->receiving = false;
+      nxmutex_unlock(&priv->devlock);
+      return length;
+    }
+
+  /* Check how the radio responded to entering RX mode */
+
+  length = rn2483_read_response(priv, response, sizeof(response) - 1);
+  if (length < 0)
+    {
+      priv->receiving = false;
+      nxmutex_unlock(&priv->devlock);
+      return length;
+    }
+
+  if (strstr(response, "invalid_param"))
+    {
+      priv->receiving = false;
+      nxmutex_unlock(&priv->devlock);
+      return -EINVAL;
+    }
+  else if (strstr(response, "busy"))
+    {
+      priv->receiving = false;
+      nxmutex_unlock(&priv->devlock);
+      return -EAGAIN;
+    }
+  else if (!strstr(response, "ok"))
+    {
+      /* This means our program and radio are out of sync */
+
+      priv->receiving = false;
+      nxmutex_unlock(&priv->devlock);
+      return -EIO;
+    }
+
+  /* If we are, we're successfully in RX mode. This means another UART read
+   * will block until we actually receive something or there was a receive
+   * error.
+   * We'll receive our data in ASCII hexadecimal characters, which we need to
+   * convert to binary to return to the user.
+   * We'll read enough characters to see if the message starts with
+   * radio_rx or radio_err. If there was an error we'll return and inform the
+   * caller. If there was something received, we'll read in groups of two
+   * characters (one byte in ASCII hex) and convert the ASCII byte into a real
+   * one to put in the user buffer. Once we see a newline or we reach the end
+   * of the user buffer we'll stop.
+   */
+
+  /* Read transmission */
+
+  memset(response, 0, sizeof(response));
+
+  /* 9 is the length of either 'radio_err' or 'radio_tx ' (with trailing
+   * space) */
+
+  for (uint8_t pos = 0; pos < 10; pos++)
+    {
+      length = file_read(&priv->uart, &response[pos], 1);
+      if (length < 0)
+        {
+          priv->receiving = false;
+          nxmutex_unlock(&priv->devlock);
+          return length;
+        }
+    }
+
+  /* Check if we got radio_err, radio_tx or neither */
+
+  if (strstr(response, "radio_err"))
+    {
+      priv->receiving = false;
+      nxmutex_unlock(&priv->devlock);
+      return -EIO;
+    }
+  else if (!strstr(response, "radio_rx "))
+    {
+      /* The driver is out of sync with the radio */
+
+      priv->receiving = false;
+      nxmutex_unlock(&priv->devlock);
+      return -EIO;
+    }
+
+  /* If we're here, we were able to detect `radio_tx `
+   * Now we convert each byte from ASCII to binary in the user's buffer.
+   */
+
+  char ascii_byte[3] = {0}; /* Space for null terminator for strtoul */
+  received = 0;
+
+  while (received < buflen)
+    {
+
+      /* We should be guaranteed to read in multiples of two because we cannot
+       * receive half-bytes, and the terminating sequence is \r\n.
+       */
+
+      for (uint8_t i = 0; i < 2; i++)
+        {
+          length = file_read(&priv->uart, &ascii_byte[i], 1);
+          if (length < 0)
+            {
+              priv->receiving = false;
+              nxmutex_unlock(&priv->devlock);
+              return length;
+            }
+        }
+
+      /* Check if we got terminating characters that terminate receive */
+
+      if (ascii_byte[0] == '\r' && ascii_byte[1] == '\n')
+        {
+          priv->receiving = false;
+          break;
+        }
+
+      /* Convert to binary */
+
+      buffer[received] = (uint8_t)strtoul(ascii_byte, NULL, 16);
+      received++;
+    }
+
+  filep->f_pos += received;
   nxmutex_unlock(&priv->devlock);
-  return length;
+  return received;
 }
 
 /****************************************************************************
@@ -403,9 +569,9 @@ static ssize_t rn2483_write(FAR struct file *filep, FAR const char *buffer,
 
   err = nxmutex_lock(&priv->devlock);
   if (err < 0)
-  {
-    return err;
-  }
+    {
+      return err;
+    }
 
   return -ENOSYS;
 }
@@ -422,40 +588,40 @@ static int rn2483_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
   err = nxmutex_lock(&priv->devlock);
   if (err < 0)
-  {
-    return err;
-  }
+    {
+      return err;
+    }
 
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   if (priv->unlinked)
-  {
-    /* Do not allow operations on unlinked drivers. */
+    {
+      /* Do not allow operations on unlinked drivers. */
 
-    nxmutex_unlock(&priv->devlock);
-    return -ENODEV;
-  }
+      nxmutex_unlock(&priv->devlock);
+      return -ENODEV;
+    }
 #endif
 
   /* Handle command */
   switch (cmd)
-  {
-    // TODO: real commands
-
-  case RN2483_IOCTL_SET_FREQ:
-  {
-    FAR uint32_t *ptr = (FAR uint32_t *)((uintptr_t)arg);
-    err = rn2483_radio_set_freq(priv, *ptr);
-    if (err < 0)
     {
-      return err;
-    }
-    break;
-  }
+      // TODO: real commands
 
-  default:
-    err = -EINVAL;
-    break;
-  }
+    case RN2483_IOCTL_SET_FREQ:
+      {
+        FAR uint32_t *ptr = (FAR uint32_t *)((uintptr_t)arg);
+        err = rn2483_radio_set_freq(priv, *ptr);
+        if (err < 0)
+          {
+            return err;
+          }
+        break;
+      }
+
+    default:
+      err = -EINVAL;
+      break;
+    }
 
   nxmutex_unlock(&priv->devlock);
   return err;
@@ -476,18 +642,18 @@ static int rn2483_unlink(FAR struct inode *inode)
 
   err = nxmutex_lock(&priv->devlock);
   if (err < 0)
-  {
-    return err;
-  }
+    {
+      return err;
+    }
 
   /* Are there open references to the driver data structure? */
 
   if (priv->crefs <= 0)
-  {
-    nxmutex_destroy(&priv->devlock);
-    kmm_free(priv);
-    return 0;
-  }
+    {
+      nxmutex_destroy(&priv->devlock);
+      kmm_free(priv);
+      return 0;
+    }
 
   /* No. Just mark the driver as unlinked and free the resources when
    * the last client closes their reference to the driver.
@@ -498,29 +664,30 @@ static int rn2483_unlink(FAR struct inode *inode)
   return OK;
 }
 #endif
+
 /****************************************************************************
  * Name: rn2483_read_response
  ****************************************************************************/
 
-static int rn2483_read_response(FAR struct rn2483_dev_s *priv, char *buf, size_t buf_len)
+static int rn2483_read_response(FAR struct rn2483_dev_s *priv, char *buf,
+                                size_t buf_len)
 {
   size_t read = 0;
   ssize_t fread;
   char last = '\0';
   while (read < buf_len)
-  {
-    fread = file_read(&priv->uart, &buf[read], 1);
-    if (last == '\r' && buf[read] == '\n')
     {
-      break;
+      fread = file_read(&priv->uart, &buf[read], 1);
+      if (last == '\r' && buf[read] == '\n')
+        {
+          break;
+        }
+      last = buf[read];
+
+      if (fread < 0) return fread;
+
+      read++;
     }
-    last = buf[read];
-
-    if (fread < 0)
-      return fread;
-
-    read++;
-  }
 
   return fread;
 }
@@ -532,42 +699,45 @@ static int rn2483_read_response(FAR struct rn2483_dev_s *priv, char *buf, size_t
 static int rn2483_check_response(char *read_buffer)
 {
   if (strstr(read_buffer, "ok") != NULL)
-  {
-    syslog(LOG_INFO, "%s\n\n", SUCCESS);
-    return 0;
-  }
+    {
+      syslog(LOG_INFO, "%s\n\n", SUCCESS);
+      return 0;
+    }
   else if (strstr(read_buffer, "invalid_param") != NULL)
-  {
-    syslog(LOG_INFO, "%s\n\n", FAILURE);
-    return -EINVAL;
-  }
+    {
+      syslog(LOG_INFO, "%s\n\n", FAILURE);
+      return -EINVAL;
+    }
   else
-  {
-    syslog(LOG_INFO, "INVALID VALUE (Not 'ok' or 'invalid_param')\n\n");
-    return -EINVAL;
-  }
+    {
+      syslog(LOG_INFO, "INVALID VALUE (Not 'ok' or 'invalid_param')\n\n");
+      return -EINVAL;
+    }
 }
 
 /****************************************************************************
  * Name: rn2483_set_cr
  ****************************************************************************/
 
-static int rn2483_radio_set_cr(FAR struct rn2483_dev_s *priv, enum rn2483_cr_e cr)
+static int rn2483_radio_set_cr(FAR struct rn2483_dev_s *priv,
+                               enum rn2483_cr_e cr)
 {
   syslog(LOG_INFO, "SET: cr");
 
   char write_buffer[50];
   ssize_t written;
 
-  // written = snprintf(write_buffer, sizeof(write_buffer), "radio set cr %s\r\n", CODING_RATES[*(enum rn2483_cr_e *)data]);
-  written = snprintf(write_buffer, sizeof(write_buffer), "radio set cr %s\r\n", CODING_RATES[cr]);
+  // written = snprintf(write_buffer, sizeof(write_buffer), "radio set cr
+  // %s\r\n", CODING_RATES[*(enum rn2483_cr_e *)data]);
+  written = snprintf(write_buffer, sizeof(write_buffer),
+                     "radio set cr %s\r\n", CODING_RATES[cr]);
   syslog(LOG_INFO, "%s", write_buffer);
 
   ssize_t write_length = file_write(&priv->uart, write_buffer, written);
   if (write_length < 0)
-  {
-    return write_length;
-  }
+    {
+      return write_length;
+    }
 
   // Read
   size_t buf_len = 50;
@@ -576,34 +746,36 @@ static int rn2483_radio_set_cr(FAR struct rn2483_dev_s *priv, enum rn2483_cr_e c
   // Read data into buffer until \r\n terminating sequence reached
   int response = rn2483_read_response(priv, read_buffer, 50);
   if (response < 0)
-  {
-    return response;
-  }
+    {
+      return response;
+    }
   syslog(LOG_INFO, "%s", read_buffer);
 
   // Check if 'ok' in response
   int check_response = rn2483_check_response(read_buffer);
   if (check_response < 0)
-  {
-    return check_response;
-  }
+    {
+      return check_response;
+    }
 
   return 0;
 }
 
-static int rn2483_radio_set_mod(FAR struct rn2483_dev_s *priv, enum rn2483_mod_e mod)
+static int rn2483_radio_set_mod(FAR struct rn2483_dev_s *priv,
+                                enum rn2483_mod_e mod)
 {
   syslog(LOG_INFO, "SET: mod");
 
   char write_buffer[50];
-  ssize_t written = snprintf(write_buffer, sizeof(write_buffer), "radio set mod %s\r\n", MODULATIONS[mod]);
+  ssize_t written = snprintf(write_buffer, sizeof(write_buffer),
+                             "radio set mod %s\r\n", MODULATIONS[mod]);
   syslog(LOG_INFO, "%s", write_buffer);
 
   ssize_t write_length = file_write(&priv->uart, write_buffer, written);
   if (write_length < 0)
-  {
-    return write_length;
-  }
+    {
+      return write_length;
+    }
 
   // Read
   size_t buf_len = 50;
@@ -612,17 +784,17 @@ static int rn2483_radio_set_mod(FAR struct rn2483_dev_s *priv, enum rn2483_mod_e
   // Read data into buffer until \r\n terminating sequence reached
   int response = rn2483_read_response(priv, read_buffer, 50);
   if (response < 0)
-  {
-    return response;
-  }
+    {
+      return response;
+    }
   syslog(LOG_INFO, "%s", read_buffer);
 
   // Check if 'ok' in response
   int check_response = rn2483_check_response(read_buffer);
   if (check_response < 0)
-  {
-    return check_response;
-  }
+    {
+      return check_response;
+    }
 
   return 0;
 }
@@ -632,14 +804,15 @@ static int rn2483_radio_set_freq(FAR struct rn2483_dev_s *priv, uint32_t freq)
   syslog(LOG_INFO, "SET: freq");
 
   char write_buffer[50];
-  ssize_t written = snprintf(write_buffer, sizeof(write_buffer), "radio set freq %ld\r\n", freq);
+  ssize_t written = snprintf(write_buffer, sizeof(write_buffer),
+                             "radio set freq %ld\r\n", freq);
   syslog(LOG_INFO, "%s", write_buffer);
 
   ssize_t write_length = file_write(&priv->uart, write_buffer, written);
   if (write_length < 0)
-  {
-    return write_length;
-  }
+    {
+      return write_length;
+    }
 
   // Read
   size_t buf_len = 50;
@@ -648,17 +821,17 @@ static int rn2483_radio_set_freq(FAR struct rn2483_dev_s *priv, uint32_t freq)
   // Read data into buffer until \r\n terminating sequence reached
   int response = rn2483_read_response(priv, read_buffer, 50);
   if (response < 0)
-  {
-    return response;
-  }
+    {
+      return response;
+    }
   syslog(LOG_INFO, "%s", read_buffer);
 
   // Check if 'ok' in response
   int check_response = rn2483_check_response(read_buffer);
   if (check_response < 0)
-  {
-    return check_response;
-  }
+    {
+      return check_response;
+    }
 
   return 0;
 }
@@ -668,14 +841,15 @@ static int rn2483_radio_set_bw(FAR struct rn2483_dev_s *priv, uint16_t bw)
   syslog(LOG_INFO, "SET: bw");
 
   char write_buffer[50];
-  ssize_t written = snprintf(write_buffer, sizeof(write_buffer), "radio set bw %d\r\n", bw);
+  ssize_t written =
+      snprintf(write_buffer, sizeof(write_buffer), "radio set bw %d\r\n", bw);
   syslog(LOG_INFO, "%s", write_buffer);
 
   ssize_t write_length = file_write(&priv->uart, write_buffer, written);
   if (write_length < 0)
-  {
-    return write_length;
-  }
+    {
+      return write_length;
+    }
 
   // Read
   size_t buf_len = 50;
@@ -684,34 +858,36 @@ static int rn2483_radio_set_bw(FAR struct rn2483_dev_s *priv, uint16_t bw)
   // Read data into buffer until \r\n terminating sequence reached
   int response = rn2483_read_response(priv, read_buffer, 50);
   if (response < 0)
-  {
-    return response;
-  }
+    {
+      return response;
+    }
   syslog(LOG_INFO, "%s", read_buffer);
 
   // Check if 'ok' in response
   int check_response = rn2483_check_response(read_buffer);
   if (check_response < 0)
-  {
-    return check_response;
-  }
+    {
+      return check_response;
+    }
 
   return 0;
 }
 
-static int rn2483_radio_set_prlen(FAR struct rn2483_dev_s *priv, uint16_t prlen)
+static int rn2483_radio_set_prlen(FAR struct rn2483_dev_s *priv,
+                                  uint16_t prlen)
 {
   syslog(LOG_INFO, "SET: prlen");
 
   char write_buffer[50];
-  ssize_t written = snprintf(write_buffer, sizeof(write_buffer), "radio set prlen %d\r\n", prlen);
+  ssize_t written = snprintf(write_buffer, sizeof(write_buffer),
+                             "radio set prlen %d\r\n", prlen);
   syslog(LOG_INFO, "%s", write_buffer);
 
   ssize_t write_length = file_write(&priv->uart, write_buffer, written);
   if (write_length < 0)
-  {
-    return write_length;
-  }
+    {
+      return write_length;
+    }
 
   // Read
   size_t buf_len = 50;
@@ -720,17 +896,17 @@ static int rn2483_radio_set_prlen(FAR struct rn2483_dev_s *priv, uint16_t prlen)
   // Read data into buffer until \r\n terminating sequence reached
   int response = rn2483_read_response(priv, read_buffer, 50);
   if (response < 0)
-  {
-    return response;
-  }
+    {
+      return response;
+    }
   syslog(LOG_INFO, "%s", read_buffer);
 
   // Check if 'ok' in response
   int check_response = rn2483_check_response(read_buffer);
   if (check_response < 0)
-  {
-    return check_response;
-  }
+    {
+      return check_response;
+    }
 
   return 0;
 }
@@ -741,14 +917,15 @@ static int rn2483_radio_set_crc(FAR struct rn2483_dev_s *priv, bool crc)
 
   char write_buffer[50];
   char *data = (crc) ? "on" : "off";
-  ssize_t written = snprintf(write_buffer, sizeof(write_buffer), "radio set crc %s\r\n", data);
+  ssize_t written = snprintf(write_buffer, sizeof(write_buffer),
+                             "radio set crc %s\r\n", data);
   syslog(LOG_INFO, "%s", write_buffer);
 
   ssize_t write_length = file_write(&priv->uart, write_buffer, written);
   if (write_length < 0)
-  {
-    return write_length;
-  }
+    {
+      return write_length;
+    }
 
   // Read
   size_t buf_len = 50;
@@ -757,17 +934,17 @@ static int rn2483_radio_set_crc(FAR struct rn2483_dev_s *priv, bool crc)
   // Read data into buffer until \r\n terminating sequence reached
   int response = rn2483_read_response(priv, read_buffer, 50);
   if (response < 0)
-  {
-    return response;
-  }
+    {
+      return response;
+    }
   syslog(LOG_INFO, "%s", read_buffer);
 
   // Check if 'ok' in response
   int check_response = rn2483_check_response(read_buffer);
   if (check_response < 0)
-  {
-    return check_response;
-  }
+    {
+      return check_response;
+    }
 
   return 0;
 }
@@ -778,14 +955,15 @@ static int rn2483_radio_set_iqi(FAR struct rn2483_dev_s *priv, bool iqi)
 
   char write_buffer[50];
   char *data = (iqi) ? "on" : "off";
-  ssize_t written = snprintf(write_buffer, sizeof(write_buffer), "radio set iqi %s\r\n", data);
+  ssize_t written = snprintf(write_buffer, sizeof(write_buffer),
+                             "radio set iqi %s\r\n", data);
   syslog(LOG_INFO, "%s", write_buffer);
 
   ssize_t write_length = file_write(&priv->uart, write_buffer, written);
   if (write_length < 0)
-  {
-    return write_length;
-  }
+    {
+      return write_length;
+    }
 
   // Read
   size_t buf_len = 50;
@@ -794,17 +972,17 @@ static int rn2483_radio_set_iqi(FAR struct rn2483_dev_s *priv, bool iqi)
   // Read data into buffer until \r\n terminating sequence reached
   int response = rn2483_read_response(priv, read_buffer, 50);
   if (response < 0)
-  {
-    return response;
-  }
+    {
+      return response;
+    }
   syslog(LOG_INFO, "%s", read_buffer);
 
   // Check if 'ok' in response
   int check_response = rn2483_check_response(read_buffer);
   if (check_response < 0)
-  {
-    return check_response;
-  }
+    {
+      return check_response;
+    }
 
   return 0;
 }
@@ -814,14 +992,15 @@ static int rn2483_radio_set_pwr(FAR struct rn2483_dev_s *priv, int8_t pwr)
   syslog(LOG_INFO, "SET: pwr");
 
   char write_buffer[50];
-  ssize_t written = snprintf(write_buffer, sizeof(write_buffer), "radio set pwr %d\r\n", pwr);
+  ssize_t written = snprintf(write_buffer, sizeof(write_buffer),
+                             "radio set pwr %d\r\n", pwr);
   syslog(LOG_INFO, "%s", write_buffer);
 
   ssize_t write_length = file_write(&priv->uart, write_buffer, written);
   if (write_length < 0)
-  {
-    return write_length;
-  }
+    {
+      return write_length;
+    }
 
   // Read
   size_t buf_len = 50;
@@ -830,17 +1009,17 @@ static int rn2483_radio_set_pwr(FAR struct rn2483_dev_s *priv, int8_t pwr)
   // Read data into buffer until \r\n terminating sequence reached
   int response = rn2483_read_response(priv, read_buffer, 50);
   if (response < 0)
-  {
-    return response;
-  }
+    {
+      return response;
+    }
   syslog(LOG_INFO, "%s", read_buffer);
 
   // Check if 'ok' in response
   int check_response = rn2483_check_response(read_buffer);
   if (check_response < 0)
-  {
-    return check_response;
-  }
+    {
+      return check_response;
+    }
 
   return 0;
 }
@@ -850,14 +1029,15 @@ static int rn2483_radio_set_sf(FAR struct rn2483_dev_s *priv, uint8_t sf)
   syslog(LOG_INFO, "SET: sf");
 
   char write_buffer[50];
-  ssize_t written = snprintf(write_buffer, sizeof(write_buffer), "radio set sf sf%d\r\n", sf);
+  ssize_t written = snprintf(write_buffer, sizeof(write_buffer),
+                             "radio set sf sf%d\r\n", sf);
   syslog(LOG_INFO, "%s", write_buffer);
 
   ssize_t write_length = file_write(&priv->uart, write_buffer, written);
   if (write_length < 0)
-  {
-    return write_length;
-  }
+    {
+      return write_length;
+    }
 
   // Read
   size_t buf_len = 50;
@@ -866,17 +1046,17 @@ static int rn2483_radio_set_sf(FAR struct rn2483_dev_s *priv, uint8_t sf)
   // Read data into buffer until \r\n terminating sequence reached
   int response = rn2483_read_response(priv, read_buffer, 50);
   if (response < 0)
-  {
-    return response;
-  }
+    {
+      return response;
+    }
   syslog(LOG_INFO, "%s", read_buffer);
 
   // Check if 'ok' in response
   int check_response = rn2483_check_response(read_buffer);
   if (check_response < 0)
-  {
-    return check_response;
-  }
+    {
+      return check_response;
+    }
 
   return 0;
 }
@@ -886,14 +1066,15 @@ static int rn2483_radio_set_sync(FAR struct rn2483_dev_s *priv, uint8_t sync)
   syslog(LOG_INFO, "SET: sync");
 
   char write_buffer[50];
-  ssize_t written = snprintf(write_buffer, sizeof(write_buffer), "radio set sync %d\r\n", sync);
+  ssize_t written = snprintf(write_buffer, sizeof(write_buffer),
+                             "radio set sync %d\r\n", sync);
   syslog(LOG_INFO, "%s", write_buffer);
 
   ssize_t write_length = file_write(&priv->uart, write_buffer, written);
   if (write_length < 0)
-  {
-    return write_length;
-  }
+    {
+      return write_length;
+    }
 
   // Read
   size_t buf_len = 50;
@@ -902,92 +1083,92 @@ static int rn2483_radio_set_sync(FAR struct rn2483_dev_s *priv, uint8_t sync)
   // Read data into buffer until \r\n terminating sequence reached
   int response = rn2483_read_response(priv, read_buffer, 50);
   if (response < 0)
-  {
-    return response;
-  }
+    {
+      return response;
+    }
   syslog(LOG_INFO, "%s", read_buffer);
 
   // Check if 'ok' in response
   int check_response = rn2483_check_response(read_buffer);
   if (check_response < 0)
-  {
-    return check_response;
-  }
+    {
+      return check_response;
+    }
 
   return 0;
 }
 
-int rn2483_set_config(FAR struct rn2483_dev_s *priv)
+static int rn2483_set_config(FAR struct rn2483_dev_s *priv)
 {
   int err;
   /*  Set mod (Modulation: FSK or LoRa)*/
   err = rn2483_radio_set_mod(priv, priv->config.mod);
   if (err < 0)
-  {
-    return err;
-  }
+    {
+      return err;
+    }
   /*  Set freq (Frequency in Hz)*/
   err = rn2483_radio_set_freq(priv, priv->config.freq);
   if (err < 0)
-  {
-    return err;
-  }
+    {
+      return err;
+    }
 
   /*  Set cr*/
   err = rn2483_radio_set_cr(priv, priv->config.cr);
   if (err < 0)
-  {
-    return err;
-  }
+    {
+      return err;
+    }
 
   /*  Set bw (Bandwidth in kHz)*/
   err = rn2483_radio_set_bw(priv, priv->config.bw);
   if (err < 0)
-  {
-    return err;
-  }
+    {
+      return err;
+    }
 
   /*  Set prlen (Preamble length)*/
   err = rn2483_radio_set_prlen(priv, priv->config.prlen);
   if (err < 0)
-  {
-    return err;
-  }
+    {
+      return err;
+    }
 
   /*  Set iqi (IQ invert, true for enabled)*/
   err = rn2483_radio_set_iqi(priv, priv->config.iqi);
   if (err < 0)
-  {
-    return err;
-  }
+    {
+      return err;
+    }
 
   /*  Set crc (Cyclic redundancy check, true for enabled)*/
   err = rn2483_radio_set_crc(priv, priv->config.crc);
   if (err < 0)
-  {
-    return err;
-  }
+    {
+      return err;
+    }
 
   /*  Set pwr (Transmit output power)*/
   err = rn2483_radio_set_pwr(priv, priv->config.pwr);
   if (err < 0)
-  {
-    return err;
-  }
+    {
+      return err;
+    }
 
   /*  Set sf (Spread Factor)*/
   err = rn2483_radio_set_sf(priv, priv->config.sf);
   if (err < 0)
-  {
-    return err;
-  }
+    {
+      return err;
+    }
 
   /*  Set sync (Synchronization word)*/
   err = rn2483_radio_set_sync(priv, priv->config.sync);
   if (err < 0)
-  {
-    return err;
-  }
+    {
+      return err;
+    }
 
   return 0;
 }
@@ -1017,32 +1198,34 @@ int rn2483_register(FAR const char *devpath, FAR const char *uartpath)
 
   priv = kmm_zalloc(sizeof(struct rn2483_dev_s));
   if (priv == NULL)
-  {
-    snerr("ERROR: Failed to allocate instance.\n");
-    return -ENOMEM;
-  }
+    {
+      snerr("ERROR: Failed to allocate instance.\n");
+      return -ENOMEM;
+    }
 
   /* Initialize mutex */
 
   err = nxmutex_init(&priv->devlock);
   if (err < 0)
-  {
-    // TODO: what logging macro needs to be used
-    // snerr("ERROR: Failed to register SHT4X driver: %d\n", err);
-    kmm_free(priv);
-    return err;
-  }
+    {
+      // TODO: what logging macro needs to be used
+      // snerr("ERROR: Failed to register SHT4X driver: %d\n", err);
+      kmm_free(priv);
+      return err;
+    }
 
   /* Get access to underlying UART interface */
 
   err = file_open(&priv->uart, uartpath, O_RDWR | O_CLOEXEC);
   if (err < 0)
-  {
-    // TODO log error
-    nxmutex_destroy(&priv->devlock);
-    kmm_free(priv);
-    return err;
-  }
+    {
+      // TODO log error
+      nxmutex_destroy(&priv->devlock);
+      kmm_free(priv);
+      return err;
+    }
+
+  priv->receiving = false;
 
   /* Set configuration options. */
 
@@ -1071,31 +1254,39 @@ int rn2483_register(FAR const char *devpath, FAR const char *uartpath)
   priv->config.sf = CONFIG_LPWAN_RN2483_SPREAD;
   priv->config.sync = CONFIG_LPWAN_RN2483_SYNC;
 
-  // Dummy read to get rid of version string
+  /* Dummy read to get rid of version string that sometimes is caught on boot
+   */
 
-  size_t buf_len = 50;
-  char read_buffer[buf_len];
-  int response = rn2483_read_response(priv, read_buffer, buf_len);
-  if (response < 0)
-  {
-    return response;
-  }
+  /* char read_buffer[50]; */
+  /**/
+  /* int response = rn2483_read_response(priv, read_buffer,
+   * sizeof(read_buffer)); */
+  /* if (response < 0) */
+  /*   { */
+  /*     return response; */
+  /*   } */
 
-  // file_poll(priv->uart);
+  /* Set configuration parameters on the radio via commands */
 
-  // Set configuration parameters on the radio via commands
-  rn2483_set_config(priv);
+  err = rn2483_set_config(priv);
+  if (err < 0)
+    {
+      file_close(&priv->uart);
+      nxmutex_destroy(&priv->devlock);
+      kmm_free(priv);
+      return err;
+    }
 
   /* Register the character driver */
   err = register_driver(devpath, &g_rn2483fops, 0666, priv);
   if (err < 0)
-  {
-    // TODO: what logging macro?
-    // snerr("ERROR: Failed to register RN2483 driver: %d\n", err);
-    file_close(&priv->uart);
-    nxmutex_destroy(&priv->devlock);
-    kmm_free(priv);
-  }
+    {
+      // TODO: what logging macro?
+      // snerr("ERROR: Failed to register RN2483 driver: %d\n", err);
+      file_close(&priv->uart);
+      nxmutex_destroy(&priv->devlock);
+      kmm_free(priv);
+    }
 
   return err;
 }


### PR DESCRIPTION
## Summary

This PR introduces the logic to receive packets on the RN2483. Currently, the implementation works by putting the radio into an infinite receive mode and then waiting for an incoming packet. When the packet is received, it is converted from the ASCII hex representation into binary and put in the user's buffer.

The read function indicates EOL by returning 0 bytes. The way this is performed is by setting a `receive` flag to true within the device structure. If the read function is called when `f_pos` is greater than 0 but `receive` is set to `false`, we can be sure that a packet was returned from the last read call and now return `0` to indicate EOF (or end of packet).

This `receive` flag is also good for if a packet is received which is larger than the user buffer. If the `receive` flag is true, we should just start reading from the UART buffer as if there's a packet there and we've already received the `radio_rx` header. This logic hasn't been implemented yet.

## Impact

One step closer to a completed driver. Also enables testing transmit code between NuttX devices.

## Testing

I transmitted my callsign from the COTS Pictail board and tried using `cat /dev/rn2483` to receive on the NuttX device (Pico W). I was able to receive my call sign multiple times in a row.

I noticed that if I boot NuttX _after_ starting the transmitter, the radio device driver fails to receive all the time. I haven't resolved this yet or investigated why.