### PR TITLE
Added nau7802 odr as kconfig option

### DIFF
--- a/drivers/sensors/Kconfig
+++ b/drivers/sensors/Kconfig
@@ -218,6 +218,17 @@ config SENSORS_NAU7802_THREAD_STACKSIZE
 	---help---
 		The stack size for the worker threads that perform measurements.
 
+config SENSORS_NAU7802_ODR 
+	int "NAU7802 ODR"
+	default 0
+	---help---
+		The following are the possible values as per datasheet
+			0 -> 10HZ
+			1 -> 20HZ
+			2 -> 40HZ
+			3 -> 80HZ 
+			7 -> 320HZ 
+
 endif # SENSORS_NAU7802
 
 config BH1750FVI_I2C_FREQUENCY

--- a/drivers/sensors/nau7802.c
+++ b/drivers/sensors/nau7802.c
@@ -914,7 +914,7 @@ int nau7802_register(FAR struct i2c_master_s *i2c, int devno, uint8_t addr)
   priv->lower.ops = &g_sensor_ops;
   priv->lower.type = SENSOR_TYPE_FORCE;
   priv->enabled = false;
-  priv->odr = NAU7802_ODR_10HZ; /* 10Hz (0.1s) default ODR */
+  priv->odr = CONFIG_SENSORS_NAU7802_ODR;
 
   err = sensor_register(&priv->lower, devno);
   if (err < 0)


### PR DESCRIPTION
## Summary

The Kconfig option for the ODR was added for on the fly configuration of the system

## Impact

You can now change the ODR on the nau7802

## Testing


