### PR TITLE
 Add spi half duplex support to stm32h7 

### DIFF
--- a/arch/arm/src/stm32h7/stm32_spi.c
+++ b/arch/arm/src/stm32h7/stm32_spi.c
@@ -267,6 +267,7 @@ struct stm32_spidev_s
   struct pm_callback_s pm_cb;    /* PM callbacks */
 #endif
   enum spi_config_e config;      /* full/half duplex, simplex transmit/read only */
+  bool              rx_now;      /* Half duplex internal */
 };
 
 /****************************************************************************
@@ -285,6 +286,8 @@ static inline void spi_writeword(struct stm32_spidev_s *priv,
 #ifdef CONFIG_DEBUG_SPI_INFO
 static inline void spi_dumpregs(struct stm32_spidev_s *priv);
 #endif
+
+static inline int spi_enable(struct stm32_spidev_s *priv, bool state);
 
 /* DMA support */
 
@@ -957,9 +960,13 @@ static inline uint32_t spi_readword(struct stm32_spidev_s *priv)
 
   if (priv->config == HALF_DUPLEX)
     {
+      /* Wait for TX to complete before switching direction */
+
+      while ((spi_getreg(priv, STM32_SPI_SR_OFFSET) & SPI_SR_TXC) == 0);
+
       /* Enable AFCNTR to preserve alternate functions */
 
-      spi_modifyreg(priv, STM32_SPI_CFG2_OFFSET, 0, SPI_CFG2_AFCNTR)
+      spi_modifyreg(priv, STM32_SPI_CFG2_OFFSET, 0, SPI_CFG2_AFCNTR);
 
       /* Need to disable SPI to switch */
 
@@ -1022,7 +1029,7 @@ static inline void spi_writeword(struct stm32_spidev_s *priv,
   {
     /* Enable AFCNTR to preserve alternate functions */
 
-    spi_modifyreg(priv, STM32_SPI_CFG2_OFFSET, 0, SPI_CFG2_AFCNTR)
+    spi_modifyreg(priv, STM32_SPI_CFG2_OFFSET, 0, SPI_CFG2_AFCNTR);
 
     /* Need to disable SPI to switch */
 
@@ -1081,9 +1088,13 @@ static inline uint8_t spi_readbyte(struct stm32_spidev_s *priv)
 
   if (priv->config == HALF_DUPLEX)
     {
+      /* Wait for TX to complete before switching direction */
+
+      while ((spi_getreg(priv, STM32_SPI_SR_OFFSET) & SPI_SR_TXC) == 0);
+
       /* Enable AFCNTR to preserve alternate functions */
 
-      spi_modifyreg(priv, STM32_SPI_CFG2_OFFSET, 0, SPI_CFG2_AFCNTR)
+      spi_modifyreg(priv, STM32_SPI_CFG2_OFFSET, 0, SPI_CFG2_AFCNTR);
 
       /* Need to disable SPI to switch */
 
@@ -1146,7 +1157,7 @@ static inline void spi_writebyte(struct stm32_spidev_s *priv,
   {
     /* Enable AFCNTR to preserve alternate functions */
 
-    spi_modifyreg(priv, STM32_SPI_CFG2_OFFSET, 0, SPI_CFG2_AFCNTR)
+    spi_modifyreg(priv, STM32_SPI_CFG2_OFFSET, 0, SPI_CFG2_AFCNTR);
 
     /* Need to disable SPI to switch */
 
@@ -1985,15 +1996,47 @@ static uint32_t spi_send(struct spi_dev_s *dev, uint32_t wd)
    * frames, two bytes are received by a 16-bit read of the data register!
    */
 
-  if (priv->nbits > 8)
+  if (priv->config != HALF_DUPLEX)
     {
-      spi_writeword(priv, (uint16_t)(wd & 0xffff));
-      ret = spi_readword(priv);
+      if (priv->nbits > 8)
+        {
+          spi_writeword(priv, (uint16_t)(wd & 0xffff));
+          ret = spi_readword(priv);
+        }
+      else
+        {
+          spi_writebyte(priv, (uint8_t)(wd & 0xff));
+          ret = (uint32_t)spi_readbyte(priv);
+        }
     }
   else
     {
-      spi_writebyte(priv, (uint8_t)(wd & 0xff));
-      ret = (uint32_t)spi_readbyte(priv);
+      /* In half duplex we must send and receive in separate spi_send() calls */
+
+      if (!priv->rx_now)
+        {
+          if (priv->nbits > 8)
+            {
+              spi_writeword(priv, (uint16_t)(wd & 0xffff));
+            }
+          else
+            {
+              spi_writebyte(priv, (uint8_t)(wd & 0xff));
+            }
+        }
+      else
+        {
+          if (priv->nbits > 8)
+            {
+              ret = spi_readword(priv);
+            }
+          else
+            {
+              ret = (uint32_t)spi_readbyte(priv);
+            }
+
+          priv->rx_now = false;
+        }
     }
 
   /* Check and clear any error flags (Reading from the SR clears the error
@@ -2083,10 +2126,12 @@ static void spi_exchange_nodma(struct spi_dev_s *dev,
           if (src)
             {
               word = *src++;
+              priv->rx_now = false;
             }
           else
             {
               word = 0xffff;
+              priv->rx_now = true;
             }
 
           /* Exchange one word */
@@ -2116,10 +2161,12 @@ static void spi_exchange_nodma(struct spi_dev_s *dev,
           if (src)
             {
               word = *src++;
+              priv->rx_now = false;
             }
           else
             {
               word = 0xff;
+              priv->rx_now = true;
             }
 
           /* Exchange one word */

--- a/arch/arm/src/stm32h7/stm32_spi.c
+++ b/arch/arm/src/stm32h7/stm32_spi.c
@@ -953,6 +953,35 @@ static inline uint32_t spi_readword(struct stm32_spidev_s *priv)
       return 0;
     }
 
+  /* Switch half duplex to rx */
+
+  if (priv->config == HALF_DUPLEX)
+    {
+      /* Enable AFCNTR to preserve alternate functions */
+
+      spi_modifyreg(priv, STM32_SPI_CFG2_OFFSET, 0, SPI_CFG2_AFCNTR)
+
+      /* Need to disable SPI to switch */
+
+      spi_enable(priv, 0);
+
+      /* Switch SPI_CR1_HDDIR to 0 for rx */
+
+      spi_modifyreg(priv, STM32_SPI_CR1_OFFSET, SPI_CR1_HDDIR, 0);
+
+      /* Renable the SPI bus */
+
+      spi_enable(priv, true);
+
+      /* Disable AFCNTR */
+
+      spi_modifyreg(priv, STM32_SPI_CFG2_OFFSET, SPI_CFG2_AFCNTR, 0);
+
+      /* Send the CSTART to signal master mode */
+
+      spi_modifyreg(priv, STM32_SPI_CR1_OFFSET, 0, SPI_CR1_CSTART);
+    }
+
   /* Wait until the receive buffer is not empty */
 
   while ((spi_getreg(priv, STM32_SPI_SR_OFFSET) & SPI_SR_RXP) == 0);
@@ -987,6 +1016,35 @@ static inline void spi_writeword(struct stm32_spidev_s *priv,
       return;
     }
 
+  /* Switch half duplex to tx */
+  
+  if (priv->config == HALF_DUPLEX)
+  {
+    /* Enable AFCNTR to preserve alternate functions */
+
+    spi_modifyreg(priv, STM32_SPI_CFG2_OFFSET, 0, SPI_CFG2_AFCNTR)
+
+    /* Need to disable SPI to switch */
+
+    spi_enable(priv, 0);
+
+    /* Switch SPI_CR1_HDDIR to 1 for tx */
+
+    spi_modifyreg(priv, STM32_SPI_CR1_OFFSET, 0, SPI_CR1_HDDIR);
+
+    /* Renable the SPI bus */
+
+    spi_enable(priv, true);
+
+    /* Disable AFCNTR */
+
+    spi_modifyreg(priv, STM32_SPI_CFG2_OFFSET, SPI_CFG2_AFCNTR, 0);
+
+    /* Send the CSTART to signal master mode */
+
+    spi_modifyreg(priv, STM32_SPI_CR1_OFFSET, 0, SPI_CR1_CSTART);
+  }
+
   /* Wait until the transmit buffer is empty */
 
   while ((spi_getreg(priv, STM32_SPI_SR_OFFSET) & SPI_SR_TXP) == 0);
@@ -1017,6 +1075,35 @@ static inline uint8_t spi_readbyte(struct stm32_spidev_s *priv)
   if (priv->config == SIMPLEX_TX)
     {
       return 0;
+    }
+  
+  /* Switch half duplex to rx */
+
+  if (priv->config == HALF_DUPLEX)
+    {
+      /* Enable AFCNTR to preserve alternate functions */
+
+      spi_modifyreg(priv, STM32_SPI_CFG2_OFFSET, 0, SPI_CFG2_AFCNTR)
+
+      /* Need to disable SPI to switch */
+
+      spi_enable(priv, 0);
+
+      /* Switch SPI_CR1_HDDIR to 0 for rx */
+
+      spi_modifyreg(priv, STM32_SPI_CR1_OFFSET, SPI_CR1_HDDIR, 0);
+
+      /* Renable the SPI bus */
+
+      spi_enable(priv, true);
+
+      /* Disable AFCNTR */
+
+      spi_modifyreg(priv, STM32_SPI_CFG2_OFFSET, SPI_CFG2_AFCNTR, 0);
+
+      /* Send the CSTART to signal master mode */
+
+      spi_modifyreg(priv, STM32_SPI_CR1_OFFSET, 0, SPI_CR1_CSTART);
     }
 
   /* Wait until the receive buffer is not empty */
@@ -1053,6 +1140,34 @@ static inline void spi_writebyte(struct stm32_spidev_s *priv,
       return;
     }
 
+  /* Switch half duplex to tx */
+  
+  if (priv->config == HALF_DUPLEX)
+  {
+    /* Enable AFCNTR to preserve alternate functions */
+
+    spi_modifyreg(priv, STM32_SPI_CFG2_OFFSET, 0, SPI_CFG2_AFCNTR)
+
+    /* Need to disable SPI to switch */
+
+    spi_enable(priv, 0);
+
+    /* Switch SPI_CR1_HDDIR to 1 for tx */
+
+    spi_modifyreg(priv, STM32_SPI_CR1_OFFSET, 0, SPI_CR1_HDDIR);
+
+    /* Renable the SPI bus */
+
+    spi_enable(priv, true);
+
+    /* Disable AFCNTR */
+
+    spi_modifyreg(priv, STM32_SPI_CFG2_OFFSET, SPI_CFG2_AFCNTR, 0);
+
+    /* Send the CSTART to signal master mode */
+
+    spi_modifyreg(priv, STM32_SPI_CR1_OFFSET, 0, SPI_CR1_CSTART);
+  }
   /* Wait until the transmit buffer is empty */
 
   while ((spi_getreg(priv, STM32_SPI_SR_OFFSET) & SPI_SR_TXP) == 0);
@@ -1858,8 +1973,9 @@ static uint32_t spi_send(struct spi_dev_s *dev, uint32_t wd)
   spi_modifyreg(priv, STM32_SPI_IFCR_OFFSET, 0, SPI_IFCR_SUSPC);
 
   /* Master transfer start */
+  /* SIMPLE_RX can't send, HALF_DUPLEX sends CSTART at the end of switching mode */
 
-  if (priv->config != SIMPLEX_RX)
+  if (priv->config != SIMPLEX_RX && priv->config != HALF_DUPLEX)
     {
       spi_modifyreg(priv, STM32_SPI_CR1_OFFSET, 0, SPI_CR1_CSTART);
     }

--- a/drivers/sensors/Kconfig
+++ b/drivers/sensors/Kconfig
@@ -1642,16 +1642,33 @@ config SENSORS_MAX6675
 config SENSORS_LIS2MDL
 	bool "STMicro LIS2MDL 3-Axis magnetometer support"
 	default n
-	select I2C
+	select SPI if SENSORS_LIS2MDL_SPI
+	select I2C if !SENSORS_LIS2MDL_SPI
 	---help---
 		Enable UORB driver support for the STMicro LIS2MDL 3-axis magnetometer.
 
 if SENSORS_LIS2MDL
 
+config SENSORS_LIS2MDL_SPI
+	bool "Connect LIS2MDL via SPI"
+	default n
+	---help---
+		Use SPI instead of I2C to communicate with the LIS2MDL.
+
 config SENSORS_LIS2MDL_I2C_FREQUENCY
 	int "LIS2MDL I2C frequency"
+	depends on !SENSORS_LIS2MDL_SPI
 	default 1000000
 	range 1 3400000
+
+if SENSORS_LIS2MDL_SPI
+
+config SENSORS_LIS2MDL_SPI_FREQUENCY
+	int "LIS2MDL SPI frequency"
+	default 10000000
+	range 1 10000000
+
+endif # SENSORS_LIS2MDL_SPI
 
 config SENSORS_LIS2MDL_THREAD_STACKSIZE
 	int "LIS2MDL worker thread stack size"

--- a/drivers/sensors/Kconfig
+++ b/drivers/sensors/Kconfig
@@ -956,17 +956,29 @@ config LSM6DSL_I2C_FREQUENCY
 config SENSORS_LSM6DSO32
 	bool "LSM6DSO32 support"
 	default n
-	select I2C
+	select SPI if SENSORS_LSM6DSO32_SPI
+	select I2C if !SENSORS_LSM6DSO32_SPI
 	---help---
 		Enable driver support for the STMicro LSM6DSO32 IMU.
 
+config SENSORS_LSM6DSO32_SPI
+	bool "Connect LSM6DSO32 via SPI"
+	default n
+	depends on SENSORS_LSM6DSO32
+
 config SENSORS_LSM6DSO32_I2C_FREQUENCY
-	int "LSM6DSO32 frequency"
+	int "LSM6DSO32 I2C frequency"
 	default 400000
 	range 1 400000
-	depends on SENSORS_LSM6DSO32
+	depends on SENSORS_LSM6DSO32 && !SENSORS_LSM6DSO32_SPI
 	---help---
 		The I2C frequency used to communicate with the LSM6DSO32.
+
+config SENSORS_LSM6DSO32_SPI_FREQUENCY
+	int "LSM6DSO32 SPI frequency"
+	default 10000000
+	range 1 10000000
+	depends on SENSORS_LSM6DSO32_SPI
 
 config SENSORS_LSM6DSO32_THREAD_STACKSIZE
 	int "LSM6DSO32 worker thread stack size"

--- a/drivers/sensors/lis2mdl_uorb.c
+++ b/drivers/sensors/lis2mdl_uorb.c
@@ -34,7 +34,11 @@
 
 #include <nuttx/clock.h>
 #include <nuttx/fs/fs.h>
-#include <nuttx/i2c/i2c_master.h>
+#ifdef CONFIG_SENSORS_LIS2MDL_SPI
+#  include <nuttx/spi/spi.h>
+#else
+#  include <nuttx/i2c/i2c_master.h>
+#endif
 #include <nuttx/kmalloc.h>
 #include <nuttx/kthread.h>
 #include <nuttx/mutex.h>
@@ -131,8 +135,7 @@ enum lis2mdl_mode_e
 struct lis2mdl_dev_s
 {
   struct sensor_lowerhalf_s lower; /* UORB lower-half */
-  FAR struct i2c_master_s *i2c;    /* I2C interface */
-  uint8_t addr;                    /* I2C address */
+  struct lis2mdl_config_s config;  /* SPI/I2C interface config */
   sem_t run;                       /* Polling cycle lock */
   mutex_t devlock;                 /* Exclusive access to device */
   enum lis2mdl_odr_e odr;          /* Configured ODR */
@@ -236,11 +239,59 @@ static const struct sensor_ops_s g_sensor_ops =
  ****************************************************************************/
 
 /****************************************************************************
- * Name: lis2mdl_read_reg
+ * Name: lis2mdl_read_reg / lis2mdl_write_reg
  *
  * Description:
- *   Read `nbytes` from the register at `addr` into `buf`.
+ *   Read/write registers over SPI or I2C depending on build configuration.
  ****************************************************************************/
+
+#ifdef CONFIG_SENSORS_LIS2MDL_SPI
+
+static int lis2mdl_read_reg(FAR struct lis2mdl_dev_s *dev, uint8_t addr,
+                            void *buf, uint8_t nbytes)
+{
+  FAR struct spi_dev_s *spi = dev->config.spi;
+  int id = dev->config.spi_devid;
+
+  SPI_LOCK(spi, true);
+  SPI_SETMODE(spi, SPIDEV_MODE0);
+  SPI_SETBITS(spi, 8);
+  SPI_SETFREQUENCY(spi, CONFIG_SENSORS_LIS2MDL_SPI_FREQUENCY);
+  SPI_SELECT(spi, id, true);
+  SPI_SEND(spi, addr | 0x80); /* bit 7 = read */
+  for (uint8_t i = 0; i < nbytes; i++)
+    {
+      ((uint8_t *)buf)[i] = (uint8_t)SPI_SEND(spi, 0xff);
+    }
+
+  SPI_SELECT(spi, id, false);
+  SPI_LOCK(spi, false);
+  return nbytes;
+}
+
+static int lis2mdl_write_reg(FAR struct lis2mdl_dev_s *dev, uint8_t addr,
+                             void *buf, uint8_t nbytes)
+{
+  FAR struct spi_dev_s *spi = dev->config.spi;
+  int id = dev->config.spi_devid;
+
+  SPI_LOCK(spi, true);
+  SPI_SETMODE(spi, SPIDEV_MODE0);
+  SPI_SETBITS(spi, 8);
+  SPI_SETFREQUENCY(spi, CONFIG_SENSORS_LIS2MDL_SPI_FREQUENCY);
+  SPI_SELECT(spi, id, true);
+  SPI_SEND(spi, addr); /* bit 7 = 0, write */
+  for (uint8_t i = 0; i < nbytes; i++)
+    {
+      SPI_SEND(spi, ((uint8_t *)buf)[i]);
+    }
+
+  SPI_SELECT(spi, id, false);
+  SPI_LOCK(spi, false);
+  return nbytes;
+}
+
+#else
 
 static int lis2mdl_read_reg(FAR struct lis2mdl_dev_s *dev, uint8_t addr,
                             void *buf, uint8_t nbytes)
@@ -248,29 +299,22 @@ static int lis2mdl_read_reg(FAR struct lis2mdl_dev_s *dev, uint8_t addr,
   struct i2c_msg_s readcmd[2] = {
       {
           .frequency = CONFIG_SENSORS_LIS2MDL_I2C_FREQUENCY,
-          .addr = dev->addr,
+          .addr = dev->config.addr,
           .flags = I2C_M_NOSTOP,
           .buffer = &addr,
           .length = sizeof(addr),
       },
       {
           .frequency = CONFIG_SENSORS_LIS2MDL_I2C_FREQUENCY,
-          .addr = dev->addr,
+          .addr = dev->config.addr,
           .flags = I2C_M_READ,
           .buffer = buf,
           .length = nbytes,
       },
   };
 
-  return I2C_TRANSFER(dev->i2c, readcmd, 2);
+  return I2C_TRANSFER(dev->config.i2c, readcmd, 2);
 }
-
-/****************************************************************************
- * Name: lis2mdl_write_reg
- *
- * Description:
- *   Write `nbytes` from `buf` to the registers starting at `addr`.
- ****************************************************************************/
 
 static int lis2mdl_write_reg(FAR struct lis2mdl_dev_s *dev, uint8_t addr,
                              void *buf, uint8_t nbytes)
@@ -278,22 +322,24 @@ static int lis2mdl_write_reg(FAR struct lis2mdl_dev_s *dev, uint8_t addr,
   struct i2c_msg_s writecmd[2] = {
       {
           .frequency = CONFIG_SENSORS_LIS2MDL_I2C_FREQUENCY,
-          .addr = dev->addr,
+          .addr = dev->config.addr,
           .flags = I2C_M_NOSTOP,
           .buffer = &addr,
           .length = sizeof(addr),
       },
       {
           .frequency = CONFIG_SENSORS_LIS2MDL_I2C_FREQUENCY,
-          .addr = dev->addr,
+          .addr = dev->config.addr,
           .flags = I2C_M_NOSTART,
           .buffer = buf,
           .length = nbytes,
       },
   };
 
-  return I2C_TRANSFER(dev->i2c, writecmd, 2);
+  return I2C_TRANSFER(dev->config.i2c, writecmd, 2);
 }
+
+#endif /* CONFIG_SENSORS_LIS2MDL_SPI */
 
 /****************************************************************************
  * Name: lis2mdl_read_data
@@ -1253,7 +1299,7 @@ static int lis2mdl_thread(int argc, char **argv)
  *
  ****************************************************************************/
 
-int lis2mdl_register(FAR struct i2c_master_s *i2c, int devno, uint8_t addr,
+int lis2mdl_register(FAR struct lis2mdl_config_s *config, int devno,
                      lis2mdl_attach attach)
 {
   FAR struct lis2mdl_dev_s *priv;
@@ -1261,8 +1307,13 @@ int lis2mdl_register(FAR struct i2c_master_s *i2c, int devno, uint8_t addr,
   FAR char *argv[2];
   char arg1[32];
 
-  DEBUGASSERT(i2c != NULL);
-  DEBUGASSERT(addr == 0x1e);
+  DEBUGASSERT(config != NULL);
+#ifdef CONFIG_SENSORS_LIS2MDL_SPI
+  DEBUGASSERT(config->spi != NULL);
+#else
+  DEBUGASSERT(config->i2c != NULL);
+  DEBUGASSERT(config->addr == 0x1e);
+#endif
 
   /* High priority work queue is required for interrupt driven mode */
 
@@ -1286,8 +1337,7 @@ int lis2mdl_register(FAR struct i2c_master_s *i2c, int devno, uint8_t addr,
 
   memset(priv, 0, sizeof(struct lis2mdl_dev_s));
 
-  priv->i2c = i2c;
-  priv->addr = addr;
+  priv->config = *config;
 
   err = nxmutex_init(&priv->devlock);
   if (err < 0)

--- a/drivers/sensors/lsm6dso32_uorb.c
+++ b/drivers/sensors/lsm6dso32_uorb.c
@@ -30,7 +30,11 @@
 #include <debug.h>
 
 #include <nuttx/fs/fs.h>
-#include <nuttx/i2c/i2c_master.h>
+#ifdef CONFIG_SENSORS_LSM6DSO32_SPI
+#  include <nuttx/spi/spi.h>
+#else
+#  include <nuttx/i2c/i2c_master.h>
+#endif
 #include <nuttx/kmalloc.h>
 #include <nuttx/kthread.h>
 #include <nuttx/mutex.h>
@@ -205,8 +209,7 @@ struct lsm6dso32_dev_s
 {
   struct lsm6dso32_sens_s gyro;  /* Gyroscope */
   struct lsm6dso32_sens_s accel; /* Accelerometer lower half */
-  FAR struct i2c_master_s *i2c;  /* I2C interface. */
-  uint8_t addr;                  /* I2C address. */
+  struct lsm6dso32_bus_config_s bus; /* SPI/I2C interface config. */
   float gy_off[3];               /* Offsets for gyroscope measurements */
   mutex_t devlock;
 };
@@ -321,75 +324,95 @@ static const struct sensor_ops_s g_sensor_ops =
  *
  ****************************************************************************/
 
+#ifdef CONFIG_SENSORS_LSM6DSO32_SPI
+
+static int lsm6dso32_write_bytes(FAR struct lsm6dso32_dev_s *priv,
+                                 uint8_t addr, void *buf, size_t nbytes)
+{
+  FAR struct spi_dev_s *spi = priv->bus.spi;
+  int id = priv->bus.spi_devid;
+
+  SPI_LOCK(spi, true);
+  SPI_SETMODE(spi, SPIDEV_MODE0);
+  SPI_SETBITS(spi, 8);
+  SPI_SETFREQUENCY(spi, CONFIG_SENSORS_LSM6DSO32_SPI_FREQUENCY);
+  SPI_SELECT(spi, id, true);
+  SPI_SEND(spi, addr);
+  for (size_t i = 0; i < nbytes; i++)
+    {
+      SPI_SEND(spi, ((uint8_t *)buf)[i]);
+    }
+
+  SPI_SELECT(spi, id, false);
+  SPI_LOCK(spi, false);
+  return nbytes;
+}
+
+static int lsm6dso32_read_bytes(FAR struct lsm6dso32_dev_s *priv,
+                                uint8_t addr, void *buf, size_t nbytes)
+{
+  FAR struct spi_dev_s *spi = priv->bus.spi;
+  int id = priv->bus.spi_devid;
+
+  SPI_LOCK(spi, true);
+  SPI_SETMODE(spi, SPIDEV_MODE0);
+  SPI_SETBITS(spi, 8);
+  SPI_SETFREQUENCY(spi, CONFIG_SENSORS_LSM6DSO32_SPI_FREQUENCY);
+  SPI_SELECT(spi, id, true);
+  SPI_SEND(spi, addr | 0x80);
+  for (size_t i = 0; i < nbytes; i++)
+    {
+      ((uint8_t *)buf)[i] = (uint8_t)SPI_SEND(spi, 0xff);
+    }
+
+  SPI_SELECT(spi, id, false);
+  SPI_LOCK(spi, false);
+  return nbytes;
+}
+
+#else
+
 static int lsm6dso32_write_bytes(FAR struct lsm6dso32_dev_s *priv,
                                  uint8_t addr, void *buf, size_t nbytes)
 {
   struct i2c_msg_s cmd[2];
 
-  /* Register addressing part of command. */
-
   cmd[0].frequency = CONFIG_SENSORS_LSM6DSO32_I2C_FREQUENCY;
-  cmd[0].addr = priv->addr;
+  cmd[0].addr = priv->bus.addr;
   cmd[0].flags = I2C_M_NOSTOP;
   cmd[0].buffer = &addr;
   cmd[0].length = sizeof(addr);
 
-  /* Data to write. */
-
   cmd[1].frequency = CONFIG_SENSORS_LSM6DSO32_I2C_FREQUENCY;
-  cmd[1].addr = priv->addr;
+  cmd[1].addr = priv->bus.addr;
   cmd[1].flags = I2C_M_NOSTART;
   cmd[1].buffer = buf;
   cmd[1].length = nbytes;
 
-  /* Send command over the wire */
-
-  return I2C_TRANSFER(priv->i2c, cmd, 2);
+  return I2C_TRANSFER(priv->bus.i2c, cmd, 2);
 }
-
-/****************************************************************************
- * Name: lsm6dso32_read_bytes
- *
- * Description:
- *   Read bytes from the LSM6DSO32 sensor. Reading more than one byte will
- *   read from sequential registers starting at the provided address.
- *
- * Input Parameters:
- *   priv    - The instance of the LSM6DSO32 sensor.
- *   addr    - The register address to read from.
- *   buf     - The buffer of data to read into.
- *   nbytes  - The number of bytes to read into the buffer.
- *
- * Returned Value:
- *   Zero (OK) on success; a negated errno value on failure.
- *
- ****************************************************************************/
 
 static int lsm6dso32_read_bytes(FAR struct lsm6dso32_dev_s *priv,
                                 uint8_t addr, void *buf, size_t nbytes)
 {
   struct i2c_msg_s cmd[2];
 
-  /* Register addressing part of command. */
-
   cmd[0].frequency = CONFIG_SENSORS_LSM6DSO32_I2C_FREQUENCY;
-  cmd[0].addr = priv->addr;
+  cmd[0].addr = priv->bus.addr;
   cmd[0].flags = I2C_M_NOSTOP;
   cmd[0].buffer = &addr;
   cmd[0].length = sizeof(addr);
 
-  /* Read data into buffer. */
-
   cmd[1].frequency = CONFIG_SENSORS_LSM6DSO32_I2C_FREQUENCY;
-  cmd[1].addr = priv->addr;
+  cmd[1].addr = priv->bus.addr;
   cmd[1].flags = I2C_M_READ;
   cmd[1].buffer = buf;
   cmd[1].length = nbytes;
 
-  /* Send command over the wire */
-
-  return I2C_TRANSFER(priv->i2c, cmd, 2);
+  return I2C_TRANSFER(priv->bus.i2c, cmd, 2);
 }
+
+#endif /* CONFIG_SENSORS_LSM6DSO32_SPI */
 
 /****************************************************************************
  * Name: lsm6dso32_set_bits
@@ -1819,7 +1842,7 @@ early_ret:
  *
  ****************************************************************************/
 
-int lsm6dso32_register(FAR struct i2c_master_s *i2c, uint8_t addr,
+int lsm6dso32_register(FAR struct lsm6dso32_bus_config_s *bus,
                        uint8_t devno, struct lsm6dso32_config_s *config)
 {
   FAR struct lsm6dso32_dev_s *priv;
@@ -1828,8 +1851,13 @@ int lsm6dso32_register(FAR struct i2c_master_s *i2c, uint8_t addr,
   char arg1[32];
   int gyro_pid;
 
-  DEBUGASSERT(i2c != NULL);
-  DEBUGASSERT(addr == 0x6b || addr == 0x6a);
+  DEBUGASSERT(bus != NULL);
+#ifdef CONFIG_SENSORS_LSM6DSO32_SPI
+  DEBUGASSERT(bus->spi != NULL);
+#else
+  DEBUGASSERT(bus->i2c != NULL);
+  DEBUGASSERT(bus->addr == 0x6b || bus->addr == 0x6a);
+#endif
 
   /* If HPWORK is not enabled and the attach functions are not NULL, let the
    * user know that HPWORK is required for interrupts.
@@ -1871,8 +1899,7 @@ int lsm6dso32_register(FAR struct i2c_master_s *i2c, uint8_t addr,
       return -ENOMEM;
     }
 
-  priv->i2c = i2c;
-  priv->addr = addr;
+  priv->bus = *bus;
 
   /* Create mutex */
 

--- a/drivers/wireless/lpwan/rn2xx3/rn2xx3.c
+++ b/drivers/wireless/lpwan/rn2xx3/rn2xx3.c
@@ -1475,11 +1475,14 @@ parse_packet:
 
   while (received < buflen)
     {
-      ret = file_read(&priv->uart, &hex_byte, 2);
-      if (ret < 2)
-        {
-          goto early_ret;
-        }
+      ret = file_read(&priv->uart, &hex_byte, 1);
+      if(ret < 1){
+        goto early_ret;
+      }
+      ret = file_read(&priv->uart, &hex_byte[1], 1);
+      if(ret < 1){
+        goto early_ret;
+      }
 
       if (hex_byte[0] == '\r' && hex_byte[1] == '\n')
         {

--- a/include/nuttx/sensors/lis2mdl.h
+++ b/include/nuttx/sensors/lis2mdl.h
@@ -24,6 +24,7 @@
  * Included Files
  ****************************************************************************/
 
+#include <nuttx/config.h>
 #include <nuttx/sensors/ioctl.h>
 #include <nuttx/irq.h>
 
@@ -31,9 +32,24 @@
  * Public Types
  ****************************************************************************/
 
+#ifdef CONFIG_SENSORS_LIS2MDL_SPI
+struct spi_dev_s; /* Forward reference */
+#else
 struct i2c_master_s; /* Forward reference */
+#endif
 
 typedef int (*lis2mdl_attach)(xcpt_t, FAR void *arg);
+
+struct lis2mdl_config_s
+{
+#ifdef CONFIG_SENSORS_LIS2MDL_SPI
+  FAR struct spi_dev_s *spi;
+  int spi_devid;
+#else
+  FAR struct i2c_master_s *i2c;
+  uint8_t addr;
+#endif
+};
 
 /****************************************************************************
  * Public Function Prototypes
@@ -46,9 +62,7 @@ typedef int (*lis2mdl_attach)(xcpt_t, FAR void *arg);
  *   Register the LIS2MDL device as a UORB sensor.
  *
  * Input Parameters:
- *   i2c     - An instance of the I2C interface to use to communicate with
- *             the LIS2MDL.
- *   addr    - The I2C address of the LIS2MDL. Should always be 0x1e.
+ *   config  - SPI or I2C interface configuration.
  *   devno   - The device number to use for the topic (i.e. /dev/mag0)
  *   attach  - A function which is called by this driver to attach the
  *             LIS2MDL interrupt handler to an IRQ. Pass NULL to operate
@@ -60,5 +74,5 @@ typedef int (*lis2mdl_attach)(xcpt_t, FAR void *arg);
  *
  ****************************************************************************/
 
-int lis2mdl_register(FAR struct i2c_master_s *i2c, int devno, uint8_t addr,
+int lis2mdl_register(FAR struct lis2mdl_config_s *config, int devno,
                      lis2mdl_attach attach);

--- a/include/nuttx/sensors/lsm6dso32.h
+++ b/include/nuttx/sensors/lsm6dso32.h
@@ -27,13 +27,30 @@
  * Included Files
  ****************************************************************************/
 
+#include <nuttx/config.h>
 #include <nuttx/irq.h>
-#include <nuttx/i2c/i2c_master.h>
 #include <nuttx/sensors/ioctl.h>
 
 /****************************************************************************
  * Public Types
  ****************************************************************************/
+
+#ifdef CONFIG_SENSORS_LSM6DSO32_SPI
+struct spi_dev_s;
+#else
+struct i2c_master_s;
+#endif
+
+struct lsm6dso32_bus_config_s
+{
+#ifdef CONFIG_SENSORS_LSM6DSO32_SPI
+  FAR struct spi_dev_s *spi;
+  int spi_devid;
+#else
+  FAR struct i2c_master_s *i2c;
+  uint8_t addr;
+#endif
+};
 
 /* LSM6DSO32 interrupt pins */
 
@@ -82,7 +99,7 @@ struct lsm6dso32_config_s
  *
  ****************************************************************************/
 
-int lsm6dso32_register(FAR struct i2c_master_s *i2c, uint8_t addr,
+int lsm6dso32_register(FAR struct lsm6dso32_bus_config_s *bus,
                        uint8_t devno, struct lsm6dso32_config_s *config);
 
 #endif // __INCLUDE_NUTTX_SENSORS_LSM6DSO32_H


### PR DESCRIPTION
Unsure why it's including your rn2483 changes. 

Compiles, not tested yet. 
May need to change the clock sources in board.h of Josh Jr. if it complains about the clock frequency when compiling. 